### PR TITLE
fix: update Dockerfile and test_maven_repo.py to use environment vari…

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -36,9 +36,9 @@ RUN set -eux; \
 
 COPY testing /app
 # 安装 playwright
-ENV GOPROXY='https://build-nexus.alauda.cn/repository/golang/,direct'
 RUN set -eux; \
     cd /app && \
+    export GOPROXY='https://build-nexus.alauda.cn/repository/golang/,direct' && \
     CGO_ENABLED=0 go test -c -o /tools/bin/nexus.test ./
 
 FROM docker-mirrors.alauda.cn/library/python:3.12-slim

--- a/testing/nexus-e2e/test_maven_repo.py
+++ b/testing/nexus-e2e/test_maven_repo.py
@@ -14,7 +14,7 @@ def test_maven_publish(nexus_client, nexus_config, hosted_repo):
             create_server_config("nexus", nexus_config.username, nexus_config.password),
         ]
         mirrors_configs = [
-            create_mirror_config("ucloud", "central", "http://ucloud-nexus.alauda.cn:8081", "maven-central")
+            create_mirror_config("ucloud", "central", os.environ.get("MACVEN_MIRROR_REGISTRY", "http://ucloud-nexus.alauda.cn:8081"), "maven-central")
         ]
         settings_path = create_settings(server_configs, mirrors_configs)
         publish_xml_path = project_path / 'publish.xml'
@@ -58,7 +58,7 @@ def test_maven_publish(nexus_client, nexus_config, hosted_repo):
         ]
         mirrors_configs = [
             create_mirror_config("nexus","nexus", nexus_config.url, hosted_repo),
-            create_mirror_config("ucloud", "central", "http://ucloud-nexus.alauda.cn:8081", "maven-central")
+            create_mirror_config("ucloud", "central", os.environ.get("MACVEN_MIRROR_REGISTRY", "http://ucloud-nexus.alauda.cn:8081"), "maven-central")
         ]
         settings_path = create_settings(server_configs, mirrors_configs)
         project_path = Path(f'test_projects/maven')
@@ -80,7 +80,7 @@ def test_maven_proxy(nexus_client, nexus_config):
             "maven",
             "maven-central",
             "proxy",
-            "http://ucloud-nexus.alauda.cn:8081/repository/maven-central/"
+            r"{}/repository/maven-central/".format(os.environ.get("MACVEN_MIRROR_REGISTRY", "http://ucloud-nexus.alauda.cn:8081"))
         )
 
     with allure.step('Download dependency'):


### PR DESCRIPTION
…able for mirror registry

- Updated Dockerfile to set GOPROXY environment variable correctly during build.
- Modified test_maven_repo.py to use environment variable for MACVEN_MIRROR_REGISTRY in mirror configuration, enhancing flexibility for different environments.